### PR TITLE
ci(templates): add PR/issue templates, PR-title linter, and reviewable gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug in provider-checkly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filing a bug report. Please fill out the sections below
+        so we can reproduce and fix the issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: Provider version
+      description: Output of the provider image tag or Helm chart version.
+      placeholder: v1.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: crossplane-version
+    attributes:
+      label: Crossplane version
+      placeholder: v1.18.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: resource
+    attributes:
+      label: Affected resource(s)
+      description: Which managed resource or claim is affected?
+      placeholder: Alert, AlertChannel, CheckGroup, ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal YAML or steps to trigger the bug.
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / events
+      description: Provider pod logs, Kubernetes events, or error messages.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that might help (screenshots, related issues, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement. Please describe what you need
+        and why so we can evaluate and prioritise it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you've tried.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else (links, screenshots, related issues).
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,35 +1,17 @@
-<!--
-Thank you for helping to improve Crossplane!
+## What
 
-Please read through https://git.io/fj2m9 if this is your first time opening a
-Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
-you need any help contributing.
--->
+<!-- Short description of the change -->
 
-### Description of your changes
+## Why
 
-<!--
-Briefly describe what this pull request does. Be sure to direct your reviewers'
-attention to anything that needs special consideration.
+<!-- Why this change is needed -->
 
-We love pull requests that resolve an open Crossplane issue. If yours does, you
-can uncomment the below line to indicate which issue your PR fixes, for example
-"Fixes #500":
+## Test plan
 
--->
-Fixes #
+- [ ] Unit tests added/updated
+- [ ] `make generate` idempotent
+- [ ] Manual E2E on sandbox (if behavioural)
 
-I have:
+## Linked issues
 
-- [ ] Read and followed Crossplane's [contribution process].
-- [ ] Run `make reviewable test` to ensure this PR is ready for review.
-
-### How has this code been tested
-
-<!--
-Before reviewers can be confident in the correctness of this pull request, it
-needs to tested and shown to be correct. Briefly describe the testing that has
-already been done or which is planned for this change.
--->
-
-[contribution process]: https://git.io/fj2m9
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,30 @@ jobs:
       - name: Deploying locally built provider package
         run: make local-deploy
 
+  reviewable:
+    # Summary job for branch protection. Gate on this single check instead of
+    # listing every CI job individually — adding/renaming jobs won't break the
+    # branch-protection rule.
+    runs-on: ubuntu-24.04
+    needs:
+      - detect-noop
+      - report-breaking-changes
+      - lint
+      - check-diff
+      - unit-tests
+      - local-deploy
+    if: always()
+    steps:
+      - name: Check job results
+        run: |
+          # Succeed when all jobs passed or were skipped (noop).
+          if [[ "${{ needs.detect-noop.result }}" == "failure" ]]; then exit 1; fi
+          if [[ "${{ needs.report-breaking-changes.result }}" == "failure" ]]; then exit 1; fi
+          if [[ "${{ needs.lint.result }}" == "failure" ]]; then exit 1; fi
+          if [[ "${{ needs.check-diff.result }}" == "failure" ]]; then exit 1; fi
+          if [[ "${{ needs.unit-tests.result }}" == "failure" ]]; then exit 1; fi
+          if [[ "${{ needs.local-deploy.result }}" == "failure" ]]; then exit 1; fi
+
   publish-artifacts:
     runs-on: ubuntu-24.04
     needs:

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: PR Title
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must not start with an uppercase letter.
+            Use lowercase conventional-commit style, e.g. "fix: correct alert reconciliation".

--- a/docs/maintainers/branch-protection.md
+++ b/docs/maintainers/branch-protection.md
@@ -1,0 +1,31 @@
+# Branch Protection — `main`
+
+Settings applied in **GitHub UI** → Settings → Branches → Branch protection rules.
+
+## Rule: `main`
+
+| Setting | Value |
+|---------|-------|
+| Require a pull request before merging | Yes |
+| Required approvals | 1 |
+| Require status checks to pass before merging | Yes |
+| Required status checks | `reviewable`, `PR Title` |
+| Require branches to be up-to-date before merging | Yes |
+| Require linear history | Yes |
+| Restrict who can push to matching branches | `sanmoh-hombal` |
+
+## Why these settings
+
+- **1 approval** — every change gets a second pair of eyes without creating a bottleneck on a small team.
+- **Status checks** — `reviewable` is a summary job in `ci.yml` that gates on all CI jobs (lint, check-diff, unit-tests, local-deploy, report-breaking-changes). `PR Title` enforces conventional commits. Gating on `reviewable` instead of individual jobs means adding or renaming CI jobs won't break the branch protection rule.
+- **Up-to-date branch** — prevents merging stale branches that haven't been rebased against the latest `main`.
+- **Linear history** — squash/rebase only; keeps `git log` readable and `git bisect` practical.
+- **Restricted pushes** — only `sanmoh-hombal` can push directly (for emergencies); everyone else goes through PRs.
+
+## Applying changes
+
+All settings are managed manually in the GitHub UI. If you need to update them:
+
+1. Go to **Settings → Branches → `main`** in the GitHub repo.
+2. Edit the branch protection rule.
+3. Update this document to match.


### PR DESCRIPTION
## Summary

- Replace boilerplate PR template with structured What/Why/Test plan/Linked issues format
- Add structured bug report and feature request issue templates (YAML forms)
- Add `pr-title.yaml` workflow to enforce conventional-commit PR titles via `amannn/action-semantic-pull-request` (SHA-pinned)
- Add `reviewable` summary job to `ci.yml` — single required check that gates on all CI jobs
- Document branch protection settings in `docs/maintainers/branch-protection.md`

## Test plan

- [ ] CI passes on this PR (confirms `reviewable` and `PR Title` checks run)
- [ ] After merge, `reviewable` and `PR Title` are selectable in branch protection UI
- [ ] Issue templates render correctly via "New Issue" on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)